### PR TITLE
Implement per-channel queues and advanced playback controls

### DIFF
--- a/utils/ai_handler.py
+++ b/utils/ai_handler.py
@@ -145,15 +145,14 @@ class AIHandler:
             
             # Context: Music Status
             music_context = ""
-            if self.bot:
+            if self.bot and guild_id:
                 music_cog = self.bot.get_cog("MusicCommands")
-                if music_cog and music_cog.current:
-                    # music_cog.current is (url, title) tuple
-                    try:
-                        title = music_cog.current[1]
-                        music_context = f"CURRENTLY PLAYING MUSIC: '{title}'. If the user asks about the music, refer to this."
-                    except Exception as e:
-                        logger.error(f"Error fetching music context: {e}")
+                if music_cog:
+                    # Retrieve comprehensive status for the server
+                    guild = self.bot.get_guild(guild_id)
+                    if guild:
+                        status_str = music_cog.get_music_status(guild)
+                        music_context = f"CURRENT FACILITY MUSIC STATUS:\n{status_str}\nIf the user asks what is playing, report this exact status."
             
             # 3. Create prompt
             system_prompt = self._get_persona_system_prompt()


### PR DESCRIPTION
Closes #86 closes #85 closes #83 closes #82 

Refactors the music cog to support independent queues for each voice channel and adds several new playback control commands.
Key Changes:
- **Per-Channel Queues**: Replaced global `self.queue` with `self.queues` dictionary keyed by channel ID.
- **Context Switching**: The [play](cci:1://file:///c:/Users/dood3/Documents/%21Projects/DiscordBot/commands/music.py:224:4-373:130) command now detects if the user is in a different channel and automatically moves the bot and switches the active queue context.
- **New Commands**:
  - `/clear`: Clears the queue for the current channel.
  - `/list`: Alias for `/queue` to view upcoming tracks.
  - `/fast-forward [seconds]`: Seeks forward in the current track (restarts stream with offset).
  - `/play-pause`: Toggles pause/resume state.
- **Logic Updates**:
  - Implemented `start_time` and `pause_start_times` tracking to ensure seek calculations remain accurate after pausing.
  - Updated [play_next](cci:1://file:///c:/Users/dood3/Documents/%21Projects/DiscordBot/commands/music.py:87:4-213:45) to handle seeking logic without modifying history.
  - Updated `stop` to clean up all per-channel state dictionaries.